### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/AgentCrew/modules/custom_llm/service.py
+++ b/AgentCrew/modules/custom_llm/service.py
@@ -78,9 +78,13 @@ class CustomLLMService(OpenAIService):
     async def process_message(self, prompt: str, temperature: float = 0) -> str:
         try:
             # Check if using GitHub Copilot
-            if self.base_url and self.base_url.endswith("githubcopilot.com"):
-                self.base_url = self.base_url.rstrip("/")
-                self.github_copilot_token_to_open_ai_key(self.api_key)
+            if self.base_url:
+                from urllib.parse import urlparse
+                parsed_url = urlparse(self.base_url)
+                host = parsed_url.hostname
+                if host and host.endswith(".githubcopilot.com"):
+                    self.base_url = self.base_url.rstrip("/")
+                    self.github_copilot_token_to_open_ai_key(self.api_key)
 
             response = await self.client.chat.completions.create(
                 model=self.model,

--- a/AgentCrew/modules/custom_llm/service.py
+++ b/AgentCrew/modules/custom_llm/service.py
@@ -80,6 +80,7 @@ class CustomLLMService(OpenAIService):
             # Check if using GitHub Copilot
             if self.base_url:
                 from urllib.parse import urlparse
+
                 parsed_url = urlparse(self.base_url)
                 host = parsed_url.hostname
                 if host and host.endswith(".githubcopilot.com"):
@@ -134,9 +135,14 @@ class CustomLLMService(OpenAIService):
     async def stream_assistant_response(self, messages):
         """Stream the assistant's response with tool support."""
         # Check if using GitHub Copilot
-        if self.base_url and self.base_url.rstrip("/").endswith("githubcopilot.com"):
-            # Update client with new key
-            self.github_copilot_token_to_open_ai_key(self.api_key)
+        if self.base_url:
+            from urllib.parse import urlparse
+
+            parsed_url = urlparse(self.base_url)
+            host = parsed_url.hostname
+            if host and host.endswith(".githubcopilot.com"):
+                self.base_url = self.base_url.rstrip("/")
+                self.github_copilot_token_to_open_ai_key(self.api_key)
 
         stream_params = {
             "model": self.model,


### PR DESCRIPTION
Potential fix for [https://github.com/saigontechnology/AgentCrew/security/code-scanning/2](https://github.com/saigontechnology/AgentCrew/security/code-scanning/2)

To fix the issue, the code should use a robust URL parsing method to validate the domain of `self.base_url`. Specifically, the `urlparse` function from Python's `urllib.parse` module can be used to extract the hostname from the URL. The hostname can then be checked to ensure it matches `githubcopilot.com` or its subdomains. This approach prevents bypasses caused by malformed URLs.

The fix involves:
1. Parsing `self.base_url` using `urlparse`.
2. Extracting the hostname from the parsed URL.
3. Validating that the hostname ends with `.githubcopilot.com`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
