### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/saigontechnology/AgentCrew/security/code-scanning/1](https://github.com/saigontechnology/AgentCrew/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. Since the workflow does not appear to require write access to any GitHub resources, the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimal access required to perform its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
