### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/AgentCrew/modules/a2a/common/server/auth_middleware.py
+++ b/AgentCrew/modules/a2a/common/server/auth_middleware.py
@@ -19,7 +19,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         self.api_key = api_key or "default-api-key"  # You can configure this
         self.logger = logger or logging.getLogger(__name__)
         self.logger.debug(
-            f"AuthMiddleware initialized with API key: {self.api_key[:8]}..."
+            "AuthMiddleware initialized."
         )
 
     async def dispatch(self, request: Request, call_next):


### PR DESCRIPTION
Potential fix for [https://github.com/saigontechnology/AgentCrew/security/code-scanning/12](https://github.com/saigontechnology/AgentCrew/security/code-scanning/12)

To fix the problem, we should avoid logging any part of the API key, even partially, in the initialization log message. Instead, we can log that the middleware was initialized without including the API key value. This change should be made in the `__init__` method of the `AuthMiddleware` class, specifically on line 22. No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
