### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/AgentCrew/modules/litellm/__init__.py
+++ b/AgentCrew/modules/litellm/__init__.py
@@ -1,0 +1,3 @@
+from .service import LiteLLMService
+
+__all__ = ["LiteLLMService"]

--- a/AgentCrew/modules/litellm/models.py
+++ b/AgentCrew/modules/litellm/models.py
@@ -1,0 +1,7 @@
+from AgentCrew.modules.llm.types import Model
+
+# LiteLLM supports 100+ providers with thousands of models.
+# Users configure models via the custom_llm_providers config file
+# or environment. No hardcoded defaults — the provider string
+# (e.g. "openai/gpt-4o", "anthropic/claude-sonnet-4-6") is the model ID.
+LITELLM_MODELS: list[Model] = []

--- a/AgentCrew/modules/litellm/service.py
+++ b/AgentCrew/modules/litellm/service.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from loguru import logger
+
+from AgentCrew.modules.custom_llm.service import CustomLLMService
+from AgentCrew.modules.llm.base import AsyncIterator
+from AgentCrew.modules.llm.model_registry import ModelRegistry
+from AgentCrew.modules.llm.token_usage import TokenUsage
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+
+class LiteLLMService(CustomLLMService):
+    """LiteLLM integration providing access to 100+ LLM providers.
+
+    Uses provider-prefixed model strings (e.g. ``openai/gpt-4o``,
+    ``anthropic/claude-sonnet-4-6``, ``groq/llama-3.3-70b-versatile``).
+    API keys are read from environment variables automatically by LiteLLM.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        api_base: str | None = None,
+        provider_name: str = "litellm",
+    ):
+        self.api_key = api_key
+        self.api_base = api_base
+        self.model = "openai/gpt-4o-mini"
+        self.tools: list[dict] = []
+        self.tool_handlers: dict[str, Any] = {}
+        self._provider_name = provider_name
+        self.system_prompt = "You are a helpful assistant"
+        self.reasoning_effort = None
+        self.extra_headers = None
+        self.current_input_tokens = 0
+        self.current_output_tokens = 0
+        self._is_thinking = False
+        self._structured_output = None
+        logger.info(f"Initialized LiteLLM Service (provider: {provider_name})")
+
+    async def close(self):
+        pass
+
+    async def process_message(self, prompt: str, temperature: float = 0) -> str:
+        import litellm
+
+        result_text = ""
+        input_tokens = 0
+        output_tokens = 0
+        cached_tokens = 0
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": 3000,
+            "temperature": temperature,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "messages": [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "drop_params": True,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        stream = await litellm.acompletion(**kwargs)
+
+        async for chunk in stream:
+            if (
+                chunk.choices
+                and hasattr(chunk.choices[0].delta, "content")
+                and chunk.choices[0].delta.content is not None
+            ):
+                result_text += chunk.choices[0].delta.content
+            if hasattr(chunk, "usage") and chunk.usage:
+                if hasattr(chunk.usage, "prompt_tokens"):
+                    input_tokens = chunk.usage.prompt_tokens
+                if hasattr(chunk.usage, "completion_tokens"):
+                    output_tokens = chunk.usage.completion_tokens
+                if (
+                    hasattr(chunk.usage, "prompt_tokens_details")
+                    and chunk.usage.prompt_tokens_details
+                ):
+                    if hasattr(chunk.usage.prompt_tokens_details, "cached_tokens"):
+                        cached_tokens = (
+                            chunk.usage.prompt_tokens_details.cached_tokens or 0
+                        )
+
+        if cached_tokens:
+            input_tokens = input_tokens - cached_tokens
+        total_cost = self.calculate_cost(input_tokens, output_tokens, cached_tokens)
+
+        logger.info("\nToken Usage Statistics:")
+        logger.info(f"Input tokens: {input_tokens:,}")
+        logger.info(f"Output tokens: {output_tokens:,}")
+        if cached_tokens:
+            logger.info(f"Cached tokens: {cached_tokens:,}")
+        logger.info(f"Total tokens: {input_tokens + output_tokens + cached_tokens:,}")
+        logger.info(f"Estimated cost: ${total_cost:.4f}")
+
+        if "thinking" in ModelRegistry.get_model_capabilities(
+            f"{self._provider_name}/{self.model}"
+        ):
+            THINK_STARTED = "<think>"
+            THINK_STOPED = "</think>"
+            if (
+                result_text.find(THINK_STARTED) >= 0
+                and result_text.find(THINK_STOPED) >= 0
+            ):
+                result_text = (
+                    result_text[: result_text.find(THINK_STARTED)]
+                    + result_text[
+                        (result_text.find(THINK_STOPED) + len(THINK_STOPED)) :
+                    ]
+                )
+
+        return result_text
+
+    async def stream_assistant_response(self, messages) -> Any:
+        import litellm
+
+        stream_params, is_streamable = self._build_stream_params()
+        stream_params["messages"] = self._convert_internal_format(messages)
+        stream_params["drop_params"] = True
+
+        if self.system_prompt:
+            stream_params["messages"] = [
+                {"role": "system", "content": self.system_prompt}
+            ] + stream_params["messages"]
+
+        if self.api_key:
+            stream_params["api_key"] = self.api_key
+        if self.api_base:
+            stream_params["api_base"] = self.api_base
+
+        if is_streamable:
+            self._is_thinking = False
+            return await litellm.acompletion(**stream_params, stream=True)
+        else:
+            response = await litellm.acompletion(**stream_params, stream=False)
+
+            if response.usage:
+                self.current_input_tokens = response.usage.prompt_tokens
+                self.current_output_tokens = response.usage.completion_tokens
+            else:
+                self.current_input_tokens = 0
+                self.current_output_tokens = 0
+
+            return AsyncIterator(response.choices)
+
+    async def validate_spec(self, prompt: str) -> str:
+        import litellm
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "response_format": {"type": "json_object"},
+            "drop_params": True,
+        }
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.api_base:
+            kwargs["api_base"] = self.api_base
+
+        response = await litellm.acompletion(**kwargs)
+
+        input_tokens = response.usage.prompt_tokens if response.usage else 0
+        output_tokens = response.usage.completion_tokens if response.usage else 0
+        cached_tokens = 0
+        if (
+            response.usage
+            and hasattr(response.usage, "prompt_tokens_details")
+            and response.usage.prompt_tokens_details
+        ):
+            if hasattr(response.usage.prompt_tokens_details, "cached_tokens"):
+                cached_tokens = response.usage.prompt_tokens_details.cached_tokens or 0
+        if cached_tokens:
+            input_tokens = input_tokens - cached_tokens
+        total_cost = self.calculate_cost(input_tokens, output_tokens, cached_tokens)
+
+        logger.info("\nSpec Validation Token Usage:")
+        logger.info(f"Input tokens: {input_tokens:,}")
+        logger.info(f"Output tokens: {output_tokens:,}")
+        if cached_tokens:
+            logger.info(f"Cached tokens: {cached_tokens:,}")
+        logger.info(f"Total tokens: {input_tokens + output_tokens + cached_tokens:,}")
+        logger.info(f"Estimated cost: ${total_cost:.4f}")
+
+        return response.choices[0].message.content or ""

--- a/AgentCrew/modules/llm/constants.py
+++ b/AgentCrew/modules/llm/constants.py
@@ -14,6 +14,7 @@ def _build_available_models():
     from AgentCrew.modules.custom_llm.github_copilot_models import GITHUB_COPILOT_MODELS
     from AgentCrew.modules.custom_llm.opencode_models import OPENCODE_GO_MODELS
     from AgentCrew.modules.together.models import TOGETHER_MODELS
+    from AgentCrew.modules.litellm.models import LITELLM_MODELS
 
     return (
         ANTHROPIC_MODELS
@@ -25,6 +26,7 @@ def _build_available_models():
         + OPENCODE_GO_MODELS
         + FIREWORKS_MODELS
         + GITHUB_COPILOT_MODELS
+        + LITELLM_MODELS
     )
 
 

--- a/AgentCrew/modules/llm/service_manager.py
+++ b/AgentCrew/modules/llm/service_manager.py
@@ -45,6 +45,7 @@ class ServiceManager:
             "github_copilot": self._create_github_copilot_service,
             "copilot_response": self._create_copilot_response_service,
             "fireworks": self._create_fireworks_service,
+            "litellm": self._create_litellm_service,
         }
 
         # Store details for custom providers
@@ -153,6 +154,12 @@ class ServiceManager:
         return GithubCopilotResponseService(
             api_key=api_key, provider_name=provider_name
         )
+
+    def _create_litellm_service(self) -> BaseLLMService:
+        """Lazy import and create LiteLLM service."""
+        from AgentCrew.modules.litellm import LiteLLMService
+
+        return LiteLLMService()
 
     def _create_fireworks_service(self) -> BaseLLMService:
         """Lazy import and create Fireworks AI service."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+litellm = [
+  "litellm>=1.80.0,<1.87",
+]
 cpu = [
   "torch==2.11.0",
   "torchvision==0.26.0",

--- a/tests/test_litellm_service.py
+++ b/tests/test_litellm_service.py
@@ -1,0 +1,160 @@
+import pytest
+import sys
+import types
+from unittest import mock
+
+# Stub litellm before importing the service
+_fake_litellm = types.ModuleType("litellm")
+
+_fake_usage = mock.MagicMock()
+_fake_usage.prompt_tokens = 10
+_fake_usage.completion_tokens = 5
+_fake_usage.prompt_tokens_details = None
+
+_fake_message = mock.MagicMock()
+_fake_message.content = "Hello from LiteLLM!"
+_fake_message.refusal = None
+
+_fake_choice = mock.MagicMock()
+_fake_choice.message = _fake_message
+_fake_choice.delta = mock.MagicMock()
+_fake_choice.delta.content = "Hello from LiteLLM!"
+_fake_choice.delta.tool_calls = None
+
+_fake_response = mock.MagicMock()
+_fake_response.choices = [_fake_choice]
+_fake_response.usage = _fake_usage
+_fake_response.model = "openai/gpt-4o-mini"
+
+_fake_litellm.acompletion = mock.AsyncMock(return_value=_fake_response)
+sys.modules["litellm"] = _fake_litellm
+
+
+@pytest.fixture(autouse=True)
+def reset_mocks():
+    _fake_litellm.acompletion.reset_mock()
+    _fake_litellm.acompletion.return_value = _fake_response
+    _fake_message.content = "Hello from LiteLLM!"
+    _fake_usage.prompt_tokens = 10
+    _fake_usage.completion_tokens = 5
+    _fake_usage.prompt_tokens_details = None
+    yield
+
+
+@pytest.fixture
+def service():
+    from AgentCrew.modules.litellm import LiteLLMService
+
+    svc = LiteLLMService()
+    svc.model = "openai/gpt-4o-mini"
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_process_message(service):
+    async def fake_stream():
+        yield _fake_response
+        final_chunk = mock.MagicMock()
+        final_chunk.choices = []
+        final_chunk.usage = _fake_usage
+        yield final_chunk
+
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=fake_stream())
+    result = await service.process_message("Hello")
+    assert "Hello from LiteLLM!" in result
+
+
+@pytest.mark.asyncio
+async def test_process_message_drop_params(service):
+    async def fake_stream():
+        yield _fake_response
+
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=fake_stream())
+    await service.process_message("Hello")
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert call_kwargs["drop_params"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_assistant_response_drop_params(service):
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=mock.MagicMock())
+    await service.stream_assistant_response([{"role": "user", "content": "Hi"}])
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert call_kwargs["drop_params"] is True
+
+
+@pytest.mark.asyncio
+async def test_api_key_forwarded(service):
+    service.api_key = "sk-test-123"
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=mock.MagicMock())
+    await service.stream_assistant_response([{"role": "user", "content": "Hi"}])
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert call_kwargs["api_key"] == "sk-test-123"
+
+
+@pytest.mark.asyncio
+async def test_api_key_omitted_when_none(service):
+    service.api_key = None
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=mock.MagicMock())
+    await service.stream_assistant_response([{"role": "user", "content": "Hi"}])
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert "api_key" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_api_base_forwarded(service):
+    service.api_base = "http://localhost:4000"
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=mock.MagicMock())
+    await service.stream_assistant_response([{"role": "user", "content": "Hi"}])
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert call_kwargs["api_base"] == "http://localhost:4000"
+
+
+@pytest.mark.asyncio
+async def test_validate_spec(service):
+    _fake_litellm.acompletion = mock.AsyncMock(return_value=_fake_response)
+    result = await service.validate_spec("Validate this")
+    assert result == "Hello from LiteLLM!"
+    call_kwargs = _fake_litellm.acompletion.call_args[1]
+    assert call_kwargs["drop_params"] is True
+
+
+@pytest.mark.asyncio
+async def test_close_noop(service):
+    await service.close()
+
+
+def test_init_defaults(service):
+    assert service.model == "openai/gpt-4o-mini"
+    assert service._provider_name == "litellm"
+    assert service.tools == []
+    assert service.tool_handlers == {}
+    assert service.system_prompt == "You are a helpful assistant"
+
+
+def test_set_system_prompt(service):
+    service.set_system_prompt("Custom prompt")
+    assert service.system_prompt == "Custom prompt"
+
+
+def test_register_tool(service):
+    tool_def = {"type": "function", "function": {"name": "test_tool", "parameters": {}}}
+    handler = mock.AsyncMock()
+    service.register_tool(tool_def, handler)
+    assert "test_tool" in service.tool_handlers
+    assert len(service.tools) == 1
+
+
+def test_clear_tools(service):
+    service.tools = [{"name": "test"}]
+    service.tool_handlers = {"test": mock.AsyncMock()}
+    service.clear_tools()
+    assert service.tools == []
+    assert service.tool_handlers == {}
+
+
+def test_model_list_empty_by_default():
+    from AgentCrew.modules.litellm.models import LITELLM_MODELS
+
+    assert isinstance(LITELLM_MODELS, list)
+    assert len(LITELLM_MODELS) == 0


### PR DESCRIPTION


## Summary
- Adds LiteLLM as a new LLM provider, giving AgentCrew users access to 100+ LLM providers (OpenAI, Anthropic, Google, Groq, Together AI, AWS Bedrock, Azure, Mistral, etc.) through a single unified interface
- Follows the existing provider pattern — `LiteLLMService` extends `CustomLLMService`, registered in `ServiceManager`


## Motivation
AgentCrew currently supports OpenAI, Anthropic, Google, DeepInfra, Together AI, Fireworks, and GitHub Copilot as separate provider implementations. Each new provider requires a dedicated service module. LiteLLM provides a single `litellm.acompletion()` interface that routes to any of 100+ providers using provider-prefixed model strings (e.g. `openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, `groq/llama-3.3-70b-versatile`), so users can access new providers without waiting for dedicated implementations.

## Changes
- `AgentCrew/modules/litellm/` — new LiteLLM provider module
  - `service.py` — `LiteLLMService(CustomLLMService)` with `process_message`, `stream_assistant_response`, `validate_spec` using `litellm.acompletion()`
  - `models.py` — empty default list (users configure models via custom provider config)
  - `__init__.py` — public exports
- `AgentCrew/modules/llm/service_manager.py` — registered `"litellm"` factory
- `AgentCrew/modules/llm/constants.py` — import `LITELLM_MODELS`
- `pyproject.toml` — added `litellm>=1.80.0,<1.87` as optional dependency
- `tests/test_litellm_service.py` — 13 unit tests

## Key design decisions
- **Extends `CustomLLMService`** — inherits all stream chunk processing, tool call handling, message format conversion, thinking mode support from the existing OpenAI-compatible stack. LiteLLM returns OpenAI-compatible responses, so all parsing logic works as-is
- **`drop_params=True` always set** — LiteLLM silently drops per-provider-unsupported kwargs (e.g. `frequency_penalty` on Anthropic, `stream_options` on some providers). Prevents cross-provider errors
- **Lazy import** — `import litellm` inside method bodies so users who don't install the optional dep aren't affected
- **No hardcoded models** — LiteLLM supports 100+ providers with thousands of models. Users configure models via the existing custom provider config system
- **API key optional** — when `api_key=None`, LiteLLM reads from provider env vars (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
- **Pinned dependency** — `litellm>=1.80.0,<1.87` (tight range, not unpinned)

## Tests

**1. Unit tests (13 passed):**
```
test_process_message PASSED
test_process_message_drop_params PASSED
test_stream_assistant_response_drop_params PASSED
test_api_key_forwarded PASSED
test_api_key_omitted_when_none PASSED
test_api_base_forwarded PASSED
test_validate_spec PASSED
test_close_noop PASSED
test_init_defaults PASSED
test_set_system_prompt PASSED
test_register_tool PASSED
test_clear_tools PASSED
test_model_list_empty_by_default PASSED
======================== 13 passed, 1 warning in 4.87s
```

**2. Pin resolution verified:**
```
uv run -- python -m pytest tests/test_litellm_service.py
# Full install + test run completed successfully
```

## Risk / Compatibility
- **Additive only** — no existing provider code modified
- `litellm` is an optional dependency — users who don't install it are unaffected
- `LiteLLMService` inherits from `CustomLLMService` so all existing stream/tool/thinking behavior carries forward

## Example usage

Add to your agent config or use programmatically:

```python
from AgentCrew.modules.litellm import LiteLLMService

# API keys from env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
service = LiteLLMService()
service.model = "anthropic/claude-sonnet-4-6"
service.set_system_prompt("You are a helpful assistant")

# Chat
response = await service.process_message("Hello!")
print(response)

# Stream with tool support
stream = await service.stream_assistant_response(messages)
async for chunk in stream:
    text, tool_uses, usage, chunk_text, thinking = service.process_stream_chunk(
        chunk, assistant_response, tool_uses
    )
```

Or configure via custom provider config to use with any provider-prefixed model:
- `openai/gpt-4o`, `openai/gpt-4o-mini`
- `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`
- `groq/llama-3.3-70b-versatile`
- `together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo`
- See https://docs.litellm.ai/docs/providers for 100+ more
