### PR TITLE
fix(console): remove duplicate exit message on Ctrl+C

### DIFF
--- a/AgentCrew/modules/console/input_handler.py
+++ b/AgentCrew/modules/console/input_handler.py
@@ -167,9 +167,6 @@ class InputHandler:
                 hasattr(self, "_last_ctrl_c_time")
                 and current_time - self._last_ctrl_c_time <= 1
             ):
-                self.console.print(
-                    Text("\n🎮 Confirmed exit. Goodbye!", style=RICH_STYLE_YELLOW_BOLD)
-                )
                 # Don't try to join from within the same thread - just exit
                 event.app.exit("__EXIT__")
             else:


### PR DESCRIPTION
The "Confirmed exit. Goodbye!" message was printed twice when exiting via double Ctrl+C - once in the key binding handler and again in the queue handler that receives the __EXIT__ sentinel. Removed the print from the key binding handler since the queue handler already handles it.