### PR TITLE
Add example in Documentation for custom provider (Ollama)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -149,6 +149,38 @@ Add OpenAI-compatible providers like llama.cpp, Ollama, or LM Studio:
 }
 ```
 
+```json
+  "custom_llm_providers": [
+    {
+      "name": "ollama",
+      "type": "openai_compatible",
+      "api_base_url": "http://localhost:11434/v1",
+      "api_key": "ollama", # any string for placeholder
+      "default_model_id": "llama3.2:latest",
+      "available_models": [
+        {
+          "id": "llama3.2:latest",
+          "name": "Ollama llama3.2:latest",
+          "provider": "ollama",
+          "capabilities": ["tool_use", "stream"],
+          "default": true,
+          "description": "Local Ollama model",
+          "input_token_price_1m": 0.0,
+          "output_token_price_1m": 0.0,
+          "cached_token_price_1m": 0.0,
+          "default_reasoning": null,
+          "max_context_token": 72000,
+          "service_name": null,
+          "force_sample_params": null
+        }
+      ],
+      "is_stream": false,
+      "extra_headers": {}
+    }
+  ]
+}
+```
+
 **Fields:**
 
 - `name` - Unique identifier for the provider

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Or store keys in `~/.AgentCrew/config.json`:
 }
 ```
 
+Custom providers:
+
+Custom providers such as Ollama, llama.cpp, and LM Studio are configured in
+the same `~/.AgentCrew/config.json` file.
+See [Custom LLM Providers](CONFIGURATION.md#custom-llm-providers) for the full
+schema, llama.cpp configuration, model capabilities, and sampling options.
+
 **All supported providers:**
 
 | Provider         | Cost profile               | Best for                               |


### PR DESCRIPTION
Resolves #46 
- Fix custom config path to follow the documentation
- Add an Ollama configuration example for custom OpenAI-compatible providers.