### PR TITLE
docs: add optional Parallel Search MCP example

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -612,6 +612,23 @@ Model Context Protocol (MCP) extends agent capabilities with external tools.
 }
 ```
 
+**Parallel Search (optional):**
+
+To opt in, manually add this entry to your own `mcp_servers.json`. The default
+Parallel Search endpoint does not require an account or API key. Only search
+queries made by the chosen agent and URLs it asks to fetch are sent to Parallel.
+
+```json
+{
+  "parallel_search": {
+    "name": "parallel_search",
+    "url": "https://search.parallel.ai/mcp",
+    "streaming_server": true,
+    "enabledForAgents": ["Researcher"]
+  }
+}
+```
+
 **Remote MCP Server using legacy SSE:**
 
 ```json


### PR DESCRIPTION
## Why

AgentCrew supports remote MCP servers, so users can opt into Parallel Search through the existing `mcp_servers.json` extension point without changing the built-in web search provider or defaults.

## Changes

- Document an optional Parallel Search remote MCP server scoped to the example `Researcher` agent.
- Note that users must add it to their own configuration, no API key is required, and only selected search queries and fetched URLs are sent to Parallel.
- Leave active configuration, Tavily, defaults, runtime, and dependencies unchanged.

## Validation

- Parsed and asserted the owned Markdown JSON example with Python in the isolated runner.
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.